### PR TITLE
Added logging to PagerDuty event API call.

### DIFF
--- a/workspace/src/github.com/previousnext/k8s-pagerduty/pagerduty.go
+++ b/workspace/src/github.com/previousnext/k8s-pagerduty/pagerduty.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"github.com/PagerDuty/go-pagerduty"
+	log "github.com/Sirupsen/logrus"
 )
 
 func pagerdutyEvent(action, serviceKey, indicentKey, description string) error {
+	log.Infof("PagerDuty %s incident - %s", action, description)
 	_, err := pagerduty.CreateEvent(pagerduty.Event{
 		Type:        action,
 		ServiceKey:  serviceKey,


### PR DESCRIPTION
#### What does this PR do?

Adds log entry when pagerduty event triggered.
 
#### How should this be manually tested?

N/A
 
#### Any background context you want to provide?

Will assist us tracking down issues with false-positive pagerduty notifications.
 
#### What are the relevant tickets?

Spurred by looking into this - https://redmine.previousnext.com.au/issues/47137
 